### PR TITLE
Include more files in the gem

### DIFF
--- a/pdf-core.gemspec
+++ b/pdf-core.gemspec
@@ -3,7 +3,9 @@ Gem::Specification.new do |spec|
   spec.version = File.read(File.expand_path('VERSION', File.dirname(__FILE__))).strip
   spec.platform = Gem::Platform::RUBY
   spec.summary = "PDF::Core is used by Prawn to render PDF documents"
-  spec.files =  Dir.glob("{lib}/**/**/*") +
+  spec.files =  Dir.glob("{lib,spec}/**/**/*") +
+                ["COPYING", "GPLv2", "GPLv3", "LICENSE"] +
+                ["Gemfile", "Rakefile"] +
                 ["pdf-core.gemspec"]
   spec.require_path = "lib"
   spec.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
Hi!

In this pull request, I propose to include more files in the gem:
- spec/ to be able to run the specs from the installed gem
- COPYING, GPLv2, GPLv3 and LICENSE, for legal reasons
- Rakefile and Gemfile to be able to use rake targets to run the tests

The README.md file is at the moment almost empty, so there is probably
no reason to include it yet.
Inclusion of Rakefile and Gemfile are may be optional, but can be useful.
The specs are also run at build time when binary packages are generated
for the Debian distribution.

Cédric
