### PR TITLE
Add document ID to trailer for PDF/X

### DIFF
--- a/lib/pdf/core/document_state.rb
+++ b/lib/pdf/core/document_state.rb
@@ -1,5 +1,3 @@
-require "securerandom"
-
 module PDF
   module Core
     class DocumentState #:nodoc:
@@ -7,7 +5,7 @@ module PDF
         normalize_metadata(options)
 
         if options[:print_scaling]
-          @store = PDF::Core::ObjectStore.new(:info => options[:info], 
+          @store = PDF::Core::ObjectStore.new(:info => options[:info],
                                               :print_scaling => options[:print_scaling])
         else
           @store = PDF::Core::ObjectStore.new(:info => options[:info])

--- a/lib/pdf/core/document_state.rb
+++ b/lib/pdf/core/document_state.rb
@@ -16,7 +16,7 @@ module PDF
         @version                 = 1.3
         @pages                   = []
         @page                    = nil
-        @trailer                 = options.fetch(:trailer, default_trailer)
+        @trailer                 = options.fetch(:trailer, {})
         @compress                = options.fetch(:compress, false)
         @encrypt                 = options.fetch(:encrypt, false)
         @encryption_key          = options[:encryption_key]
@@ -72,13 +72,6 @@ module PDF
           output << (@encrypt ? ref.encrypted_object(@encryption_key) :
                                 ref.object)
         end
-      end
-
-      private
-
-      # Document ID is required by PDF-X spec, presence ok for standard PDF
-      def default_trailer
-        { :ID => 2.times.map { SecureRandom.hex(8) }}
       end
 
     end

--- a/lib/pdf/core/document_state.rb
+++ b/lib/pdf/core/document_state.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 module PDF
   module Core
     class DocumentState #:nodoc:
@@ -14,7 +16,7 @@ module PDF
         @version                 = 1.3
         @pages                   = []
         @page                    = nil
-        @trailer                 = {}
+        @trailer                 = options.fetch(:trailer, default_trailer)
         @compress                = options.fetch(:compress, false)
         @encrypt                 = options.fetch(:encrypt, false)
         @encryption_key          = options[:encryption_key]
@@ -71,6 +73,14 @@ module PDF
                                 ref.object)
         end
       end
+
+      private
+
+      # Document ID is required by PDF-X spec, presence ok for standard PDF
+      def default_trailer
+        { :ID => 2.times.map { SecureRandom.hex(8) }}
+      end
+
     end
   end
 end

--- a/spec/document_state_spec.rb
+++ b/spec/document_state_spec.rb
@@ -15,6 +15,12 @@ describe "PDF Document State" do
   end
 
   describe "default trailer" do
+    before do
+      @state = PDF::Core::DocumentState.new({
+        trailer: { :ID => ["myDoc","versionA"] }
+      })
+    end
+
     it "should contain an ID entry with two values in trailer" do
       expect(@state.trailer[:ID].count).to eq(2)
     end

--- a/spec/document_state_spec.rb
+++ b/spec/document_state_spec.rb
@@ -14,14 +14,14 @@ describe "PDF Document State" do
     it { expect(@state.store.info.data[:Producer]).to eq("Prawn") }
   end
 
-  describe "default trailer" do
+  describe "given a trailer ID with two values" do
     before do
       @state = PDF::Core::DocumentState.new({
         trailer: { :ID => ["myDoc","versionA"] }
       })
     end
 
-    it "should contain an ID entry with two values in trailer" do
+    it "should contain the ID entry with two values in trailer" do
       expect(@state.trailer[:ID].count).to eq(2)
     end
   end

--- a/spec/document_state_spec.rb
+++ b/spec/document_state_spec.rb
@@ -1,0 +1,23 @@
+require_relative "spec_helper"
+
+describe "PDF Document State" do
+  before { @state = PDF::Core::DocumentState.new({}) }
+
+  describe "initialization" do
+    it { expect(@state.compress).to eq(false) }
+    it { expect(@state.encrypt).to eq(false) }
+    it { expect(@state.skip_encoding).to eq(false) }
+  end
+
+  describe "normalize_metadata" do
+    it { expect(@state.store.info.data[:Creator]).to eq("Prawn") }
+    it { expect(@state.store.info.data[:Producer]).to eq("Prawn") }
+  end
+
+  describe "default trailer" do
+    it "should contain an ID entry with two values in trailer" do
+      expect(@state.trailer[:ID].count).to eq(2)
+    end
+  end
+
+end

--- a/spec/document_state_spec.rb
+++ b/spec/document_state_spec.rb
@@ -7,6 +7,7 @@ describe "PDF Document State" do
     it { expect(@state.compress).to eq(false) }
     it { expect(@state.encrypt).to eq(false) }
     it { expect(@state.skip_encoding).to eq(false) }
+    it { expect(@state.trailer).to eq({}) }
   end
 
   describe "normalize_metadata" do


### PR DESCRIPTION
Adds a default trailer that includes a document ID consisting of two random hex values.  This is used for PDF-X compatibility but does not negatively affect other PDF formats.  A `:trailer` option can also be passed in during initialization which can override the default.

Also added basic specs or the PDF::Core::DocumentState class which had none.