### PR TITLE
Add bleed settings for PDF/X

### DIFF
--- a/lib/pdf/core/page.rb
+++ b/lib/pdf/core/page.rb
@@ -12,16 +12,19 @@ require_relative 'graphics_state'
 module PDF
   module Core
     class Page #:nodoc:
-      attr_accessor :document, :margins, :bleed, :stack
+      attr_accessor :document, :margins, :bleeds, :stack
       attr_writer :content, :dictionary
 
       def initialize(document, options={})
         @document = document
-        @margins  = options[:margins] || { :left    => 36,
-                                           :right   => 36,
-                                           :top     => 36,
-                                           :bottom  => 36  }
-        @bleed = options[:bleed] || 0
+        @margins  = options[:margins] || { :left   => 36,
+                                           :right  => 36,
+                                           :top    => 36,
+                                           :bottom => 36  }
+        @bleeds    = options[:bleeds] || { :left   => 0,
+                                           :right  => 0,
+                                           :top    => 0,
+                                           :bottom => 0  }
         @stack = GraphicStateStack.new(options[:graphic_state])
         if options[:object_id]
           init_from_object(options)
@@ -141,9 +144,10 @@ module PDF
         end
       end
 
-      def trim_dimensions
+      def trimbox_dimensions
         x1, y1, x2, y2 = dimensions
-        [x1 + bleed, y1 + bleed, x2 - bleed, y2 - bleed]
+        [x1 + bleeds[:left],  y1 + bleeds[:bottom],
+         x2 - bleeds[:right], y2 - bleeds[:top]]
       end
 
       private
@@ -175,7 +179,7 @@ module PDF
                                    :MediaBox    => dimensions,
                                    :CropBox     => dimensions,
                                    :BleedBox    => dimensions,
-                                   :TrimBox     => trim_dimensions,
+                                   :TrimBox     => trimbox_dimensions,
                                    :Contents    => content)
 
         resources[:ProcSet] = [:PDF, :Text, :ImageB, :ImageC, :ImageI]

--- a/lib/pdf/core/page.rb
+++ b/lib/pdf/core/page.rb
@@ -141,7 +141,7 @@ module PDF
         end
       end
 
-      def bleed_dimensions
+      def trim_dimensions
         x1, y1, x2, y2 = dimensions
         [x1 + bleed, y1 + bleed, x2 - bleed, y2 - bleed]
       end
@@ -175,7 +175,7 @@ module PDF
                                    :MediaBox    => dimensions,
                                    :CropBox     => dimensions,
                                    :BleedBox    => dimensions,
-                                   :TrimBox     => bleed_dimensions,
+                                   :TrimBox     => trim_dimensions,
                                    :Contents    => content)
 
         resources[:ProcSet] = [:PDF, :Text, :ImageB, :ImageC, :ImageI]

--- a/lib/pdf/core/page.rb
+++ b/lib/pdf/core/page.rb
@@ -12,7 +12,7 @@ require_relative 'graphics_state'
 module PDF
   module Core
     class Page #:nodoc:
-      attr_accessor :document, :margins, :stack
+      attr_accessor :document, :margins, :bleed, :stack
       attr_writer :content, :dictionary
 
       def initialize(document, options={})
@@ -21,6 +21,7 @@ module PDF
                                            :right   => 36,
                                            :top     => 36,
                                            :bottom  => 36  }
+        @bleed = options[:bleed] || 0
         @stack = GraphicStateStack.new(options[:graphic_state])
         if options[:object_id]
           init_from_object(options)
@@ -140,6 +141,11 @@ module PDF
         end
       end
 
+      def bleed_dimensions
+        x1, y1, x2, y2 = dimensions
+        [x1 + bleed, y1 + bleed, x2 - bleed, y2 - bleed]
+      end
+
       private
 
       def init_from_object(options)
@@ -167,6 +173,9 @@ module PDF
         @dictionary = document.ref(:Type        => :Page,
                                    :Parent      => document.state.store.pages,
                                    :MediaBox    => dimensions,
+                                   :CropBox     => dimensions,
+                                   :BleedBox    => dimensions,
+                                   :TrimBox     => bleed_dimensions,
                                    :Contents    => content)
 
         resources[:ProcSet] = [:PDF, :Text, :ImageB, :ImageC, :ImageI]


### PR DESCRIPTION
Allows new documents or new pages to have four independent `:bleeds` values that specify an inner TrimBox from the document dimensions (MediaBox).  This is being used in production and creates print dimensions that are compatible with the PDF/X-1A spec which requires a bleed to be defined even if it has a value of zero pts (see green and blue lines in this screenshot):

![screen shot 2015-05-26 at 2 40 02 am](https://cloud.githubusercontent.com/assets/1347/7809809/ceca4dd8-0351-11e5-8308-aa811d3366dd.png)

Tests for bleed will be submitted to `prawn` with the other Document tests for margin once this is merged in.  The default bleed if unspecified is `0` so this is backwards compatible with all previous pdf-core documents. 
