### PR TITLE
Fixing regex "/u over UTF-8 string" warning on Ruby 2

### DIFF
--- a/lib/pdf/core/pdf_object.rb
+++ b/lib/pdf/core/pdf_object.rb
@@ -58,11 +58,11 @@ module PDF
       when Array
         "[" << obj.map { |e| PdfObject(e, in_content_stream) }.join(' ') << "]"
       when PDF::Core::LiteralString
-        obj = obj.gsub(/[\\\n\r\t\b\f\(\)]/n) { |m| "\\#{m}" }
+        obj = obj.gsub(/[\\\n\r\t\b\f\(\)]/) { |m| "\\#{m}" }
         "(#{obj})"
       when Time
         obj = obj.strftime("D:%Y%m%d%H%M%S%z").chop.chop + "'00'"
-        obj = obj.gsub(/[\\\n\r\t\b\f\(\)]/n) { |m| "\\#{m}" }
+        obj = obj.gsub(/[\\\n\r\t\b\f\(\)]/) { |m| "\\#{m}" }
         "(#{obj})"
       when PDF::Core::ByteString
         "<" << obj.unpack("H*").first << ">"


### PR DESCRIPTION
Hello,
I've fixed the (irritating) regex "/u over UTF-8 string" warning on Ruby 2. Would you please merge my changes in?
Thank you for your great project!  Keep up good work!
-t