### PR TITLE
Move pdf/core/text requirement into spec

### DIFF
--- a/lib/pdf/core.rb
+++ b/lib/pdf/core.rb
@@ -16,7 +16,6 @@ require_relative 'core/page_geometry'
 require_relative 'core/outline_root'
 require_relative 'core/outline_item'
 require_relative 'core/renderer'
-require_relative 'core/text'
 
 module PDF
   module Core

--- a/spec/pdf/core/text_spec.rb
+++ b/spec/pdf/core/text_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+require 'pdf/core/text'
+
 RSpec.describe PDF::Core::Text do
   # rubocop: disable RSpec/InstanceVariable
   class TextMock


### PR DESCRIPTION
Instead of requiring pdf/core/text in pdf/core which will be used
in all requires for pdf-core, require only in the specific spec.

Addresses https://github.com/prawnpdf/pdf-core/issues/30