### PR TITLE
Fix bug in Page#inherited_dictionary_value when in a #stamp_stream block

### DIFF
--- a/lib/pdf/core/page.rb
+++ b/lib/pdf/core/page.rb
@@ -102,8 +102,11 @@ module PDF
       end
 
       def dictionary
-        defined?(@stamp_dictionary) && @stamp_dictionary ||
-          document.state.store[@dictionary]
+        defined?(@stamp_dictionary) && @stamp_dictionary || page_dictionary
+      end
+
+      def page_dictionary
+        document.state.store[@dictionary]
       end
 
       def resources
@@ -213,7 +216,9 @@ module PDF
       #     => [ 0, 0, 595, 842 ]
       #
       def inherited_dictionary_value(key, local_dict = nil)
-        local_dict ||= dictionary.data
+        # Cannot use #dictionary here, because it will return the
+        # @stamp_dictionary when called in a #stamp_stream block.
+        local_dict ||= page_dictionary.data
 
         if local_dict.key?(key)
           local_dict[key]


### PR DESCRIPTION
`#inherited_dictionary_value` used the wrong dictionary when called from a `#stamp_stream` block. It uses `@stamp_dictionary` instead of the page `@dictionary`, so a call to `page.dimensions` would return `nil`.

I added a new `#page_dictionary` method that is called by `#inherited_dictionary_value`, which always returns the correct page dictionary.

This issue surfaced while using [prawn-templates](https://github.com/prawnpdf/prawn-templates) with [prawn-blank](https://github.com/hannesg/prawn-blank) (for adding AcroForm fields.)