### PR TITLE
gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/pdf-core.gemspec
+++ b/pdf-core.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
     'gregory.t.brown@gmail.com', 'brad@bradediger.com', 'dnelson@bluejade.com',
     'greenberg@entryway.net', 'jimmy@deefa.com'
   ]
-  spec.rubyforge_project = 'prawn'
   spec.licenses = %w[PRAWN GPL-2.0 GPL-3.0]
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('pdf-inspector', '~> 1.1.0')


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.