### PR TITLE
Implement get_page_objects method

### DIFF
--- a/lib/pdf/core/object_store.rb
+++ b/lib/pdf/core/object_store.rb
@@ -96,6 +96,13 @@ module PDF
         flat_page_ids = get_page_objects(pages).flatten
         flat_page_ids[page]
       end
+
+      private
+
+      # returns an array with the object IDs for all pages
+      def get_page_objects(pages)
+        pages.data[:Kids].map(&:identifier)
+      end
     end
   end
 end


### PR DESCRIPTION
It seems that this method is actually implemented in prawn-templates. Direct support and integration of templates has been removed some time ago and moved to the prawn-templates gem.

prawn-templates has a get_page_objects method that does a bit more. For prawn itself we can just map the kids array to identifiers.

Fixes #46 