### PR TITLE
Changes pull_request_target in the CI config to pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-  pull_request_target:
+  pull_request:
   schedule:
     - cron: "6 20 * * 6"
 


### PR DESCRIPTION
This PR makes a minor change in the CI config, switching from `pull_request_target` to `pull_request` for the `on` target