### PR TITLE
Update prawn-dev to 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.5.0"
-          - "2.5"
           - "2.6.0"
           - "2.6"
           - "2.7.0"
@@ -23,7 +21,7 @@ jobs:
           - "3.0"
           - "3.1.0"
           - ruby-head
-          - jruby-9.2
+          - jruby-9.3
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby

--- a/lib/pdf/core/name_tree.rb
+++ b/lib/pdf/core/name_tree.rb
@@ -133,7 +133,7 @@ module PDF
           half = (node.limit + 1) / 2
 
           left_children = node.children[0...half]
-          right_children = node.children[half..-1]
+          right_children = node.children[half..]
 
           left.children.replace(left_children)
           right.children.replace(right_children)

--- a/pdf-core.gemspec
+++ b/pdf-core.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
     %w[Gemfile Rakefile] +
     ['pdf-core.gemspec']
   spec.require_path = 'lib'
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
   spec.required_rubygems_version = '>= 1.3.6'
 
   spec.cert_chain = ['certs/pointlessone.pem']
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.licenses = %w[PRAWN GPL-2.0 GPL-3.0]
   spec.add_development_dependency('pdf-inspector', '~> 1.1.0')
   spec.add_development_dependency('pdf-reader', '~>1.2')
-  spec.add_development_dependency('prawn-dev', '~> 0.1.0')
+  spec.add_development_dependency('prawn-dev', '~> 0.3.0')
   spec.homepage = 'http://prawnpdf.org'
   spec.description = 'PDF::Core is used by Prawn to render PDF documents'
 end

--- a/spec/pdf/core/object_store_spec.rb
+++ b/spec/pdf/core/object_store_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PDF::Core::ObjectStore do
     [10, 11, 12].each do |id|
       store.push(id, "some data #{id}")
     end
-    expect(store.map(&:identifier)[-3..-1]).to eq [10, 11, 12]
+    expect(store.map(&:identifier)[-3..]).to eq [10, 11, 12]
   end
 
   it 'accepts option to disabling PDF scaling in PDF clients' do


### PR DESCRIPTION
This update includes setting the minimum version of Ruby to 2.6 and updating Rubocop

Related changes in this commit include:

1. Updating CI to remove 2.5, 2.5.0, and jruby-9.2
2. Adding jruby-9.3
3. Minor changes to address lints