### PR TITLE
Splits spec runs from code-style, in line with the other prawnpdf repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,30 @@ on:
     - cron: "6 20 * * 6"
 
 jobs:
+  code-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.0
+      - name: Gems cache
+        uses: actions/cache@v2
+        with:
+          path: ~/gems
+          key: gems-3.1.0-${{ hashFiles('*.gemspec', 'Gemfile') }}-${{ github.sha }}
+          restore-keys: |
+            gems-3.1.0-${{ hashFiles('*.gemspec', 'Gemfile') }}-
+            gems-3.1.0-
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle config path ~/gems
+          bundle install --jobs 4 --retry 3
+      - name: Check code style
+        run: bundle exec rake rubocop
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -42,4 +66,4 @@ jobs:
           bundle config path ~/gems
           bundle install --jobs 4 --retry 3
       - name: Run tests
-        run: bundle exec rake
+        run: bundle exec rake spec


### PR DESCRIPTION
This splits out code-style as a dedicated run, and ensures that the other jobs only run rspec.  This is consistent with prawnpdf/prawn and makes it easier to distinguish test fails from Rubocop issues