### PR TITLE
Update text operator state to be resilient against exceptions in blocks

### DIFF
--- a/spec/pdf/core/text_spec.rb
+++ b/spec/pdf/core/text_spec.rb
@@ -36,7 +36,57 @@ RSpec.describe PDF::Core::Text do
     text_mock_class.new
   end
 
-  describe 'horizontal_text_scaling' do
+  describe '#text_rendering_mode' do
+    describe 'called without argument' do
+      let(:result) { mock.text_rendering_mode }
+
+      it 'functions as accessor' do
+        expect(result).to eq(:fill)
+      end
+    end
+
+    describe 'called with argument' do
+      context 'when the block does not raise an error' do
+        before do
+          mock.text_rendering_mode(:fill_stroke) do
+            mock.add_content('TEST')
+          end
+        end
+
+        it 'resets text_rendering_mode to original value' do
+          expect(mock.text_rendering_mode).to eq(:fill)
+        end
+
+        it 'outputs correct PDF content' do
+          expect(mock.text).to eq("\n2 TrTEST\n0 Tr")
+        end
+      end
+
+      context 'when the block raises an error' do
+        let(:error_message) { SecureRandom.hex(5) }
+
+        # rubocop:disable RSpec/ExpectInHook
+        before do
+          expect do
+            mock.text_rendering_mode(:fill_stroke) do
+              raise StandardError, error_message
+            end
+          end.to raise_error StandardError, error_message
+        end
+        # rubocop:enable RSpec/ExpectInHook
+
+        it 'resets text_rendering_mode to original value' do
+          expect(mock.text_rendering_mode).to eq(:fill)
+        end
+
+        it 'outputs correct PDF content' do
+          expect(mock.text).to eq("\n2 Tr\n0 Tr")
+        end
+      end
+    end
+  end
+
+  describe '#horizontal_text_scaling' do
     describe 'called without argument' do
       let(:result) { mock.horizontal_text_scaling }
 
@@ -46,23 +96,47 @@ RSpec.describe PDF::Core::Text do
     end
 
     describe 'called with argument' do
-      before do
-        mock.horizontal_text_scaling(110) do
-          mock.add_content('TEST')
+      context 'when the block does not raise an error' do
+        before do
+          mock.horizontal_text_scaling(110) do
+            mock.add_content('TEST')
+          end
+        end
+
+        it 'resets horizontal_text_scaling to original value' do
+          expect(mock.horizontal_text_scaling).to eq(100)
+        end
+
+        it 'outputs correct PDF content' do
+          expect(mock.text).to eq("\n110.0 TzTEST\n100.0 Tz")
         end
       end
 
-      it 'resets horizontal_text_scaling to original value' do
-        expect(mock.horizontal_text_scaling).to eq(100)
-      end
+      context 'when the block raises an error' do
+        let(:error_message) { SecureRandom.hex(5) }
 
-      it 'outputs correct PDF content' do
-        expect(mock.text).to eq("\n110.0 TzTEST\n100.0 Tz")
+        # rubocop:disable RSpec/ExpectInHook
+        before do
+          expect do
+            mock.horizontal_text_scaling(110) do
+              raise StandardError, error_message
+            end
+          end.to raise_error StandardError, error_message
+        end
+        # rubocop:enable RSpec/ExpectInHook
+
+        it 'resets horizontal_text_scaling to original value' do
+          expect(mock.horizontal_text_scaling).to eq(100)
+        end
+
+        it 'outputs correct PDF content' do
+          expect(mock.text).to eq("\n110.0 Tz\n100.0 Tz")
+        end
       end
     end
   end
 
-  describe 'character_spacing' do
+  describe '#character_spacing' do
     describe 'called without argument' do
       let(:result) { mock.character_spacing }
 
@@ -72,18 +146,92 @@ RSpec.describe PDF::Core::Text do
     end
 
     describe 'called with argument' do
-      before do
-        mock.character_spacing(10) do
-          mock.add_content('TEST')
+      context 'when the block does not raise an error' do
+        before do
+          mock.character_spacing(10) do
+            mock.add_content('TEST')
+          end
+        end
+
+        it 'resets character_spacing to original value' do
+          expect(mock.character_spacing).to eq(0)
+        end
+
+        it 'outputs correct PDF content' do
+          expect(mock.text).to eq("\n10.0 TcTEST\n0.0 Tc")
         end
       end
 
-      it 'resets character_spacing to original value' do
-        expect(mock.character_spacing).to eq(0)
+      context 'when the block raises an error' do
+        let(:error_message) { SecureRandom.hex(5) }
+
+        # rubocop:disable RSpec/ExpectInHook
+        before do
+          expect do
+            mock.character_spacing(10) do
+              raise StandardError, error_message
+            end
+          end.to raise_error StandardError, error_message
+        end
+        # rubocop:enable RSpec/ExpectInHook
+
+        it 'resets character_spacing to original value' do
+          expect(mock.character_spacing).to eq(0)
+        end
+
+        it 'outputs correct PDF content' do
+          expect(mock.text).to eq("\n10.0 Tc\n0.0 Tc")
+        end
+      end
+    end
+  end
+
+  describe '#word_spacing' do
+    describe 'called without argument' do
+      let(:result) { mock.word_spacing }
+
+      it 'functions as accessor' do
+        expect(result).to eq(0)
+      end
+    end
+
+    describe 'called with argument' do
+      context 'when the block does not raise an error' do
+        before do
+          mock.word_spacing(10) do
+            mock.add_content('TEST')
+          end
+        end
+
+        it 'resets word_spacing to original value' do
+          expect(mock.word_spacing).to eq(0)
+        end
+
+        it 'outputs correct PDF content' do
+          expect(mock.text).to eq("\n10.0 TwTEST\n0.0 Tw")
+        end
       end
 
-      it 'outputs correct PDF content' do
-        expect(mock.text).to eq("\n10.0 TcTEST\n0.0 Tc")
+      context 'when the block raises an error' do
+        let(:error_message) { SecureRandom.hex(5) }
+
+        # rubocop:disable RSpec/ExpectInHook
+        before do
+          expect do
+            mock.word_spacing(10) do
+              raise StandardError, error_message
+            end
+          end.to raise_error StandardError, error_message
+        end
+        # rubocop:enable RSpec/ExpectInHook
+
+        it 'resets word_spacing to original value' do
+          expect(mock.word_spacing).to eq(0)
+        end
+
+        it 'outputs correct PDF content' do
+          expect(mock.text).to eq("\n10.0 Tw\n0.0 Tw")
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ end
 require_relative '../lib/pdf/core'
 
 require 'rspec'
+require 'securerandom'
 require 'pdf/reader'
 require 'pdf/inspector'
 


### PR DESCRIPTION
Before this PR, exceptions raised in the blocks wrapping text operator state changes could corrupt the document state.  If the operator state is being set to a value different than the current document state, and the block raises an exception, then both the in-memory variable and the in-PDF page state were corrupted.  This PR adds ensure blocks to guarantee that the value of both the in-memory and the PDF state is appropriately reset.

This PR also adds some basic specs for text_rendering_mode, as those specs were absent and this PR should test the error case for that operator state as well.

There is some additional opportunity to dry up the code, as the "real" operators (character_spacing, word_spacing, horizontal_text_scaling) are all essentially identical.