### PR TITLE
Fix serialisation of literal strings and Time

### DIFF
--- a/lib/pdf/core/pdf_object.rb
+++ b/lib/pdf/core/pdf_object.rb
@@ -36,6 +36,8 @@ module PDF
 
     ESCAPED_NAME_CHARACTERS = (1..32).to_a + [35, 40, 41, 47, 60, 62] + (127..255).to_a
 
+    STRING_ESCAPE_MAP = { '(' => '\(', ')' => '\)', '\\' => '\\\\', "\r" => '\r' }.freeze
+
     # Serializes Ruby objects to their PDF equivalents.  Most primitive objects
     # will work as expected, but please note that Name objects are represented
     # by Ruby Symbol objects and Dictionary objects are represented by Ruby
@@ -64,11 +66,11 @@ module PDF
       when Array
         "[#{obj.map { |e| pdf_object(e, in_content_stream) }.join(' ')}]"
       when PDF::Core::LiteralString
-        obj = obj.gsub(/[\\\n\r\t\b\f()]/) { |m| "\\#{m}" }
+        obj = obj.gsub(/[\\\r()]/, STRING_ESCAPE_MAP)
         "(#{obj})"
       when Time
         obj = "#{obj.strftime('D:%Y%m%d%H%M%S%z').chop.chop}'00'"
-        obj = obj.gsub(/[\\\n\r\t\b\f()]/) { |m| "\\#{m}" }
+        obj = obj.gsub(/[\\\r()]/, STRING_ESCAPE_MAP)
         "(#{obj})"
       when PDF::Core::ByteString
         "<#{obj.unpack1('H*')}>"

--- a/spec/pdf/core_pdf_object_spec.rb
+++ b/spec/pdf/core_pdf_object_spec.rb
@@ -85,20 +85,8 @@ RSpec.describe PDF::Core, '.pdf_object' do
     ls = PDF::Core::LiteralString.new('abc')
     expect(described_class.pdf_object(ls)).to eq '(abc)'
 
-    ls = PDF::Core::LiteralString.new("abc\x0Ade") # should escape \n
-    expect(described_class.pdf_object(ls)).to eq "(abc\x5C\x0Ade)"
-
     ls = PDF::Core::LiteralString.new("abc\x0Dde") # should escape \r
-    expect(described_class.pdf_object(ls)).to eq "(abc\x5C\x0Dde)"
-
-    ls = PDF::Core::LiteralString.new("abc\x09de") # should escape \t
-    expect(described_class.pdf_object(ls)).to eq "(abc\x5C\x09de)"
-
-    ls = PDF::Core::LiteralString.new("abc\x08de") # should escape \b
-    expect(described_class.pdf_object(ls)).to eq "(abc\x5C\x08de)"
-
-    ls = PDF::Core::LiteralString.new("abc\x0Cde") # should escape \f
-    expect(described_class.pdf_object(ls)).to eq "(abc\x5C\x0Cde)"
+    expect(described_class.pdf_object(ls)).to eq "(abc\x5Crde)"
 
     ls = PDF::Core::LiteralString.new('abc(de') # should escape \(
     expect(described_class.pdf_object(ls)).to eq "(abc\x5C(de)"


### PR DESCRIPTION
According to the PDF spec, a literal string may contain any character
except unbalanced parentheses ( and ) and the backslash. To make it
easy, these three characters need to be escaped.

Additionally, the carriage return needs to be escaped as \\r, i.e.
a backslash followed by the letter r. If it is not escaped, a single
\r would be read as \n according to the spec. And a backslash followed
by carriage return is ignored when read. So the only way to do it is
to use \\r.