### PR TITLE
Adding US-TRADE and US-TRADE-BLEED to page_geometry.rb

### DIFF
--- a/lib/pdf/core/page_geometry.rb
+++ b/lib/pdf/core/page_geometry.rb
@@ -65,6 +65,7 @@ module PDF
     # LEGAL:: => 612.00 x 1008.00
     # LETTER:: => 612.00 x 792.00
     # TABLOID:: => 792.00 x 1224.00
+    # TRADE:: => 450.00 x 666.00
     #
     module PageGeometry
       SIZES = {
@@ -117,7 +118,9 @@ module PDF
         'FOLIO' => [612.00, 936.00],
         'LEGAL' => [612.00, 1008.00],
         'LETTER' => [612.00, 792.00],
-        'TABLOID' => [792.00, 1224.00]
+        'TABLOID' => [792.00, 1224.00],
+        'US-TRADE-BLEED' => [450.00, 666.00],
+        'US-TRADE' => [432.00, 648.00]
       }.freeze
     end
   end

--- a/lib/pdf/core/page_geometry.rb
+++ b/lib/pdf/core/page_geometry.rb
@@ -65,7 +65,8 @@ module PDF
     # LEGAL:: => 612.00 x 1008.00
     # LETTER:: => 612.00 x 792.00
     # TABLOID:: => 792.00 x 1224.00
-    # TRADE:: => 450.00 x 666.00
+    # US-TRADE-BLEED:: => 450.00 x 666.00
+    # US-TRADE:: => 432.00 x 648.00
     #
     module PageGeometry
       SIZES = {

--- a/lib/pdf/core/page_geometry.rb
+++ b/lib/pdf/core/page_geometry.rb
@@ -65,8 +65,8 @@ module PDF
     # LEGAL:: => 612.00 x 1008.00
     # LETTER:: => 612.00 x 792.00
     # TABLOID:: => 792.00 x 1224.00
-    # US-TRADE-BLEED:: => 450.00 x 666.00
-    # US-TRADE:: => 432.00 x 648.00
+    # TRADE-6.25x9.25:: => 450.00 x 666.00
+    # TRADE-6x9:: => 432.00 x 648.00
     #
     module PageGeometry
       SIZES = {
@@ -120,8 +120,8 @@ module PDF
         'LEGAL' => [612.00, 1008.00],
         'LETTER' => [612.00, 792.00],
         'TABLOID' => [792.00, 1224.00],
-        'US-TRADE-BLEED' => [450.00, 666.00],
-        'US-TRADE' => [432.00, 648.00]
+        'TRADE-6.25x9.25' => [450.00, 666.00],
+        'TRADE-6x9' => [432.00, 648.00]
       }.freeze
     end
   end


### PR DESCRIPTION
To be clear, I personally despise the United States customary units.

However the printers in my country unfortunately seem to be fond of it. 

I am adding two sizes here. 

**US-TRADE** which is the default 6" X 9" size for US Trade sized publications.
**US-TRADE-BLEED** which is the default size, with an additional .25" bleed margin (6.25" x 9.25" total)

Signed-off-by: Kris Nóva <kris@nivenly.com>