### PR TITLE
Stop requiring IO objects to have #size, #printf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Stop requiring IO objects to have `#printf` and `#size`
+  Max Chernyak
+
 ## [0.9.0][]
 
 ## Changed

--- a/lib/pdf/core.rb
+++ b/lib/pdf/core.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'core/io_wrapper'
 require_relative 'core/pdf_object'
 require_relative 'core/annotations'
 require_relative 'core/byte_string'

--- a/lib/pdf/core/io_wrapper.rb
+++ b/lib/pdf/core/io_wrapper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Implements a consistent interface for IO objects.
+
+require 'stringio'
+
+module PDF
+  module Core
+    class IoWrapper
+      attr_reader :size
+
+      def self.wrap(io)
+        return io if self === io
+        io.set_encoding(::Encoding::ASCII_8BIT) if io.instance_of?(StringIO)
+        new(io)
+      end
+
+      def initialize(io)
+        @io = io
+        @size = 0
+      end
+
+      def printf(*args, **kwargs)
+        self << sprintf(*args, **kwargs)
+      end
+
+      def <<(chunk)
+        @io << chunk
+        @size += chunk.to_s.bytesize
+        self
+      end
+
+      def string
+        return unless @io.instance_of?(StringIO)
+
+        str = @io.string
+        str.force_encoding(::Encoding::ASCII_8BIT)
+        str
+      end
+    end
+  end
+end

--- a/lib/pdf/core/renderer.rb
+++ b/lib/pdf/core/renderer.rb
@@ -155,20 +155,14 @@ module PDF
       # Pass an open file descriptor to render to file.
       #
       def render(output = StringIO.new)
-        if output.instance_of?(StringIO)
-          output.set_encoding(::Encoding::ASCII_8BIT)
-        end
+        output = IoWrapper.wrap(output)
         finalize_all_page_contents
 
         render_header(output)
         render_body(output)
         render_xref(output)
         render_trailer(output)
-        if output.instance_of?(StringIO)
-          str = output.string
-          str.force_encoding(::Encoding::ASCII_8BIT)
-          str
-        end
+        output.string
       end
 
       # Renders the PDF document to file.

--- a/spec/pdf/core/renderer_spec.rb
+++ b/spec/pdf/core/renderer_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe PDF::Core::Renderer do
+  subject(:renderer) do
+    pdf = PDF::Core::Renderer.new(PDF::Core::DocumentState.new({}))
+    pdf.start_new_page
+    pdf.add_content("#{PDF::Core.real_params([100, 500])} m")
+    pdf.add_content("#{PDF::Core.real_params([300, 550])} l")
+    pdf.add_content('S')
+    pdf
+  end
+
+  describe '.render' do
+    it 'requires output object to only support method <<' do
+      output = Class.new { def <<(*); self end }.new
+      expect { subject.render(output) }.to_not raise_error
+    end
+
+    it 'returns the rendered string when output is not given' do
+      expect(subject.render).to be_a(String)
+    end
+
+    it 'returns the rendered string when output is StringIO' do
+      expect(subject.render(StringIO.new)).to be_a(String)
+    end
+
+    it 'returns nil when output is not StringIO' do
+      output = Class.new { def <<(*); self end }.new
+      expect(subject.render(output)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Hello folks,

Long story short: this PR makes it so that `Renderer#render` accepts IO objects that only have method `<<`, and no longer require methods `size` and `printf`.

Long story long: `PDF::Core::Renderer` supports IO objects. However, it calls `output.size` and `output.printf` in a couple of places. Turns out not all IO objects have `size` and `printf`. Take [Roda Web Framework](http://roda.jeremyevans.net) for instance, with its Streaming plugin. Here's a Roda app that can stream-render a PDF straight into the user's browser.

```ruby
require 'roda'
require 'prawn'

class Web < Roda
  plugin :streaming

  route do |r|
    r.on('pdf') {
      pdf = Prawn::Document.new do
        text r.params['text']
      end

      response.headers['Content-Type'] = 'application/pdf'

      stream do |out|
        pdf.render(out) # <= This line doesn't work. This PR makes it work.
      end
    }
  end
end
```

Notice how we pass `out` to `pdf.render`. It fails because Renderer tries to check `out.size` and call `out.printf`. But Roda's stream object doesn't have those methods.

You get an error like this:

```
NoMethodError: undefined method `size' for #<Roda::RodaPlugins::Streaming::Stream>

          ref.offset = output.size
                             ^^^^^>
```

I think it's a good idea not to assume that output objects have those methods. `File` and `StringIO` have a size, but if you're streaming your output into some void (e.g. internet, USB wire, STDOUT, etc) you can't have a `size` there.

Good news is that we can actually keep track of how many bytes we've written on our side, without relying on IO object. I added a small IO wrapper that does just that, and adds consistent support for `printf` for good measure. Now any IO object gets wrapped, and gains support of size and printf, even if we're rendering into a bottomless pit.

The other good news is that it turned out to be a small and straightforward code change.

Let me know if you could find any reasons why this is a bad idea. I couldn't come up with any. Tested this with Prawn and Roda, and it streamed the file perfectly.

P.S. I found the code in `example/lines.rb` to be a good fit for writing the spec, so I borrowed it from there.

P.P.S. When rendering into a file, we no longer call `file.size` repeatedly. This avoid unnecessary `fstat` reads from disk.